### PR TITLE
Implement payment before posting is allowed

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3,6 +3,7 @@
 <head>
     <title>Pay2Post</title>
     <script src="https://unpkg.com/htmx.org@1.3.3"></script>
+    <script src="https://js.stripe.com/v3/"></script>
 </head>
 <body>
     <h1>Pay2Post</h1>
@@ -16,9 +17,49 @@
         <input type="password" name="password" placeholder="Password">
         <button type="submit">Login</button>
     </form>
+    <form id="post-form" hx-post="/posts" hx-trigger="submit" hx-target="#message" onsubmit="handlePayment(event)">
+        <textarea name="content" placeholder="Your post content..."></textarea>
+        <button type="submit">Create Post</button>
+    </form>
     <div id="message"></div>
     <div id="posts">
         <!-- Posts will be dynamically loaded here -->
     </div>
+
+    <script>
+        function handlePayment(event) {
+            event.preventDefault();
+            var stripe = Stripe('pk_test_YOUR_PUBLIC_KEY');
+
+            stripe.createToken('bank_account').then(function(result) {
+                if (result.error) {
+                    // Inform the user if there was an error
+                    var errorElement = document.getElementById('message');
+                    errorElement.textContent = result.error.message;
+                } else {
+                    // Send the token to your server
+                    fetch('/pay', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json'
+                        },
+                        body: JSON.stringify({
+                            token: result.token.id,
+                            post_id: postID // Replace with the actual post ID
+                        })
+                    }).then(function(response) {
+                        return response.json();
+                    }).then(function(data) {
+                        var messageElement = document.getElementById('message');
+                        if (data.error) {
+                            messageElement.textContent = data.error;
+                        } else {
+                            messageElement.textContent = 'Payment successful and post updated';
+                        }
+                    });
+                }
+            });
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
Related to #3

Implement payment processing using Stripe to ensure users must pay before creating a post.

* **Backend Changes:**
  - Add `paymentHandler` function in `main.go` to handle payment processing with Stripe.
  - Update `createPost` function in `main.go` to ensure posts can only be created if they are paid for.
  - Add route for payment endpoint in `main.go`.

* **Frontend Changes:**
  - Add frontend integration with HTMX in `templates/index.html` to include payment processing with Stripe before submitting a post.
  - Update form in `templates/index.html` to handle payment before creating a post.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/4cecoder/pay2post/issues/3?shareId=3e90fee6-d0a6-4b1f-b6b8-7646c7f3bb90).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new payment processing form, allowing users to submit posts while handling payments simultaneously.
	- Added integration with Stripe for secure payment processing.
	
- **Improvements**
	- Enhanced separation of payment handling from post creation, improving code clarity and maintainability.
	- Streamlined user experience by processing payments directly within the post submission workflow. 

- **Bug Fixes**
	- Resolved issues related to payment intent handling by implementing a more straightforward charge processing method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->